### PR TITLE
Prevent default options from overwriting input options.

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,9 +25,9 @@ var PACKAGE_NAME = require('./package.json').name;
 /**
  * A gulp plugin that resolves absolute url() paths relative to their original source file.
  * Requires source-maps to do any meaningful work.
- * @param {object} options Options
+ * @param {object} config Options
  */
-function resolveUrl(options) {
+function resolveUrl(config) {
   return through.obj(function (file, encoding, cb) {
 
     if (!file.sourceMap) {
@@ -37,7 +37,7 @@ function resolveUrl(options) {
     }
 
     var sourceMap = file.sourceMap;
-    var options = defaults(options || {}, {
+    var options = defaults(config || {}, {
       absolute: false,
       fail: true,
       silent: false,

--- a/test/main.js
+++ b/test/main.js
@@ -30,5 +30,20 @@ describe('gulp-resolve-url', function() {
           .pipe(assert.end(done));
       });
 
+    it('should produce urls that contain the full module path when the absolute option is included', function (done) {
+      var stream = gulp.src([path.join(basePath, "main.scss")], {base:basePath})
+        .pipe(sourcemaps.init())
+        .pipe(sass())
+        .pipe(resolveUrl({
+          root: __dirname,
+          absolute: true
+        }));
+
+      stream
+        .pipe(assert.length(1))
+        .pipe(assert.first(function (d) { d.contents.toString().should.containEql('/test/fixtures/sub/resource.png'); }))
+        .pipe(assert.end(done));
+      });
+
   });
 });


### PR DESCRIPTION
Configured options are being ignored. It seems to be the result of your defaults assignment overwriting the original. If I change the parameter name to avoid clashing with the variable assignment, the defaults are properly merged with the configured values.